### PR TITLE
Switch cvs plot to use imputed_data() directly

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -17,9 +17,10 @@ coef_variation<-function(x){
 
 #### Plot CVs
 
-plot_cvs <- function(se, id="ID", scale=T, check.names=T) {
-  
+plot_cvs <- function(se, id="ID", scale=T, check.names=T, log2_transform=FALSE) {
+
   ## backtransform data
+  if (log2_transform) assay(se) <- log2(assay(se))
   untransformed_intensity<- 2^(assay(se))
   exp_design<-colData(se)
 

--- a/server.R
+++ b/server.R
@@ -878,6 +878,15 @@ server <- function(input, output, session) {
      # diff_all <- test_diff_customized(imputed_data(), type = "manual",
      #                      test = c("SampleTypeTumor"), design_formula = formula(~0+SampleType))
      data <- imputed_data()
+     conditions <- as.character(unique(colData(data)$condition))
+     validate(need(
+       length(conditions) >= 2,
+       paste0(
+         "Differential expression analysis requires at least 2 conditions. ",
+         "Only 1 condition ('", conditions[1], "') was detected in the experiment design. ",
+         "QC plots (PCA, sample correlation, missing values, etc.) are still available."
+       )
+     ))
      if (input$exp == "LFQ" & input$lfq_type == "Spectral Count") {
        assay(data) <- log2(assay(data))
      } else if (input$exp == "LFQ-peptide" & input$lfq_pept_type == "Spectral Count") {
@@ -1437,7 +1446,13 @@ server <- function(input, output, session) {
    })
    
    cvs_input<-reactive({
-     plot_cvs(dep(), id="label", scale=!input$cvs_full_range, check.names=F)
+     data <- imputed_data()
+     if (input$exp == "LFQ" & input$lfq_type == "Spectral Count") {
+       assay(data) <- log2(assay(data))
+     } else if (input$exp == "LFQ-peptide" & input$lfq_pept_type == "Spectral Count") {
+       assay(data) <- log2(assay(data))
+     }
+     plot_cvs(data, id="label", scale=!input$cvs_full_range, check.names=F)
    })
    
    num_total <- reactive({

--- a/server.R
+++ b/server.R
@@ -1510,13 +1510,7 @@ server <- function(input, output, session) {
    })
    
    cvs_input<-reactive({
-     data <- imputed_data()
-     if (input$exp == "LFQ" & input$lfq_type == "Spectral Count") {
-       assay(data) <- log2(assay(data))
-     } else if (input$exp == "LFQ-peptide" & input$lfq_pept_type == "Spectral Count") {
-       assay(data) <- log2(assay(data))
-     }
-     plot_cvs(data, id="label", scale=!input$cvs_full_range, check.names=F)
+     plot_cvs(dep(), id="label", scale=!input$cvs_full_range, check.names=F)
    })
    
    num_total <- reactive({

--- a/server.R
+++ b/server.R
@@ -1510,7 +1510,9 @@ server <- function(input, output, session) {
    })
    
    cvs_input<-reactive({
-     plot_cvs(dep(), id="label", scale=!input$cvs_full_range, check.names=F)
+     data <- imputed_data()
+     plot_cvs(data, id="label", scale=!input$cvs_full_range, check.names=F,
+              log2_transform = !isTRUE(metadata(data)$log2transform))
    })
    
    num_total <- reactive({


### PR DESCRIPTION
Switch cvs plot to use imputed_data() directly, making the CVs plot available for single-condition experiments